### PR TITLE
call orca.read_config in orchestrator_cli.

### DIFF
--- a/scripts/orchestrator_cli
+++ b/scripts/orchestrator_cli
@@ -8,4 +8,5 @@ import sys
 
 if __name__ == '__main__':
     orca = tooling.Orca()
+    orca.read_config()
     fire.Fire(orca)


### PR DESCRIPTION
Initializes azure datalake storage account credentials for orchestrator_cli tasks.